### PR TITLE
add properties tab in the metadata section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,6 +2189,7 @@ dependencies = [
  "parquet-format",
  "polars",
  "ratatui",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ ratatui = "0.29.0"
 crossterm = "0.29.0"
 chrono = "0.4"                                          # for timestamp handling
 itertools = "0.14.0"
-polars = { version = "0.51.0", features = ["lazy", "parquet", "dtype-full", "timezones"] } 
+polars = { version = "0.51.0", features = ["lazy", "parquet", "dtype-full", "timezones"] }
+serde_json = "1"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,6 +168,7 @@ impl<'a> App<'a> {
             file_info.schema.column_size(),
             file_info.row_groups.num_row_groups(),
             sample_data_rows,
+            file_info.metadata.total_property_display_lines(),
         );
 
         Self {

--- a/src/file/metadata.rs
+++ b/src/file/metadata.rs
@@ -8,7 +8,7 @@ use ratatui::{
     style::Stylize,
     symbols::border,
     text::{Line, Span, Text},
-    widgets::{Block, Cell, Paragraph, Row, Table, Wrap},
+    widgets::{Block, Cell, Paragraph, Row, Table},
 };
 use std::collections::{HashMap, HashSet};
 
@@ -16,6 +16,17 @@ use crate::components::ScrollbarComponent;
 use crate::file::Renderable;
 use crate::file::utils::commas;
 use crate::file::utils::human_readable_bytes;
+
+/// Wrap a single line into chunks of at most `width` characters.
+fn wrap_line(line: &str, width: usize) -> Vec<String> {
+    if width == 0 || line.is_empty() {
+        return vec![line.to_string()];
+    }
+    line.as_bytes()
+        .chunks(width)
+        .map(|chunk| String::from_utf8_lossy(chunk).into_owned())
+        .collect()
+}
 
 #[derive(Debug)]
 pub struct FileMetadata {
@@ -229,21 +240,28 @@ impl FileMetadata {
             return;
         }
 
-        // Build styled display lines: key header then 2-space-indented value (JSON pretty-printed).
+        // Available width inside borders (2) minus potential scrollbar (1).
+        let wrap_width = area.width.saturating_sub(3) as usize;
+
+        // Build pre-wrapped display lines so line count matches rendered height exactly.
         let mut lines: Vec<Line> = Vec::new();
         for (i, (key, value)) in props.iter().enumerate() {
             if i > 0 {
                 lines.push(Line::from(""));
             }
             lines.push(Line::from(Span::from(key.as_str()).bold().fg(Color::Blue)));
-            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(value) {
-                let pretty =
-                    serde_json::to_string_pretty(&json_val).unwrap_or_else(|_| value.clone());
-                for json_line in pretty.lines() {
-                    lines.push(Line::from(format!("  {json_line}")));
-                }
+
+            let expanded = if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(value) {
+                serde_json::to_string_pretty(&json_val).unwrap_or_else(|_| value.clone())
             } else {
-                lines.push(Line::from(format!("  {value}")));
+                value.clone()
+            };
+
+            for text_line in expanded.lines() {
+                let indented = format!("  {text_line}");
+                for wrapped in wrap_line(&indented, wrap_width) {
+                    lines.push(Line::from(wrapped));
+                }
             }
         }
 
@@ -264,7 +282,6 @@ impl FileMetadata {
         }
 
         Paragraph::new(Text::from(lines))
-            .wrap(Wrap { trim: false })
             .scroll((start as u16, 0))
             .block(
                 Block::bordered()

--- a/src/file/metadata.rs
+++ b/src/file/metadata.rs
@@ -121,11 +121,8 @@ impl FileMetadata {
             return;
         }
 
-        let [stats_area, props_area] = Layout::horizontal([
-            Constraint::Fill(2),
-            Constraint::Fill(1),
-        ])
-        .areas(area);
+        let [stats_area, props_area] =
+            Layout::horizontal([Constraint::Fill(2), Constraint::Fill(1)]).areas(area);
 
         self.render_stats_centered(stats_area, buf);
         self.render_properties(props_area, buf, scroll);
@@ -137,14 +134,14 @@ impl FileMetadata {
             .enumerate()
             .map(|(i, (_, value))| {
                 let separator = if i > 0 { 1 } else { 0 };
-                let value_lines =
-                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
-                        serde_json::to_string_pretty(&json)
-                            .map(|s| s.lines().count())
-                            .unwrap_or(1)
-                    } else {
-                        1
-                    };
+                let value_lines = if let Ok(json) = serde_json::from_str::<serde_json::Value>(value)
+                {
+                    serde_json::to_string_pretty(&json)
+                        .map(|s| s.lines().count())
+                        .unwrap_or(1)
+                } else {
+                    1
+                };
                 separator + 1 + value_lines
             })
             .sum()
@@ -240,8 +237,8 @@ impl FileMetadata {
             }
             lines.push(Line::from(Span::from(key.as_str()).bold().fg(Color::Blue)));
             if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(value) {
-                let pretty = serde_json::to_string_pretty(&json_val)
-                    .unwrap_or_else(|_| value.clone());
+                let pretty =
+                    serde_json::to_string_pretty(&json_val).unwrap_or_else(|_| value.clone());
                 for json_line in pretty.lines() {
                     lines.push(Line::from(format!("  {json_line}")));
                 }

--- a/src/file/metadata.rs
+++ b/src/file/metadata.rs
@@ -3,15 +3,16 @@ use parquet::file::metadata::ParquetMetaData;
 use ratatui::widgets::Widget;
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Rect},
+    layout::{Constraint, Layout, Rect},
     prelude::Color,
     style::Stylize,
     symbols::border,
-    text::Line,
-    widgets::{Block, Cell, Row, Table},
+    text::{Line, Span, Text},
+    widgets::{Block, Cell, Paragraph, Row, Table},
 };
 use std::collections::{HashMap, HashSet};
 
+use crate::components::ScrollbarComponent;
 use crate::file::Renderable;
 use crate::file::utils::commas;
 use crate::file::utils::human_readable_bytes;
@@ -29,6 +30,7 @@ pub struct FileMetadata {
     pub codecs: String,
     pub encodings: String,
     pub avg_row_size: u64,
+    pub key_value_metadata: Vec<(String, String)>,
 }
 
 impl FileMetadata {
@@ -85,6 +87,16 @@ impl FileMetadata {
             .collect::<Vec<String>>()
             .join(", ");
 
+        let key_value_metadata = md
+            .file_metadata()
+            .key_value_metadata()
+            .map(|kv| {
+                kv.iter()
+                    .map(|pair| (pair.key.clone(), pair.value.clone().unwrap_or_default()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Ok(FileMetadata {
             format_version: format_version.to_string(),
             created_by: created_by.to_string(),
@@ -97,12 +109,56 @@ impl FileMetadata {
             codecs,
             encodings,
             avg_row_size: avg_row_size as u64,
+            key_value_metadata,
         })
     }
 }
 
-impl Renderable for FileMetadata {
-    fn render_content(&self, area: Rect, buf: &mut Buffer) {
+impl FileMetadata {
+    pub fn render_with_scroll(&self, area: Rect, buf: &mut Buffer, scroll: usize) {
+        if self.key_value_metadata.is_empty() {
+            self.render_stats_centered(area, buf);
+            return;
+        }
+
+        let [stats_area, props_area] = Layout::horizontal([
+            Constraint::Fill(2),
+            Constraint::Fill(1),
+        ])
+        .areas(area);
+
+        self.render_stats_centered(stats_area, buf);
+        self.render_properties(props_area, buf, scroll);
+    }
+
+    pub fn total_property_display_lines(&self) -> usize {
+        self.key_value_metadata
+            .iter()
+            .enumerate()
+            .map(|(i, (_, value))| {
+                let separator = if i > 0 { 1 } else { 0 };
+                let value_lines =
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+                        serde_json::to_string_pretty(&json)
+                            .map(|s| s.lines().count())
+                            .unwrap_or(1)
+                    } else {
+                        1
+                    };
+                separator + 1 + value_lines
+            })
+            .sum()
+    }
+
+    /// Total byte size of all key-value metadata (keys + values).
+    pub fn properties_size(&self) -> u64 {
+        self.key_value_metadata
+            .iter()
+            .map(|(k, v)| (k.len() + v.len()) as u64)
+            .sum()
+    }
+
+    fn render_stats_centered(&self, area: Rect, buf: &mut Buffer) {
         let kv_pairs: Vec<(String, String)> = vec![
             ("Format version".into(), self.format_version.clone()),
             ("Created by".into(), self.created_by.clone()),
@@ -121,6 +177,10 @@ impl Renderable for FileMetadata {
             ("Codecs (cols)".into(), self.codecs.clone()),
             ("Encodings".into(), self.encodings.clone()),
             ("Avg row size".into(), format!("{} B", self.avg_row_size)),
+            (
+                "Properties size".into(),
+                human_readable_bytes(self.properties_size()),
+            ),
         ];
 
         let max_value_size = kv_pairs.iter().map(|(_, v)| v.len()).max().unwrap_or(0) as u16;
@@ -135,20 +195,21 @@ impl Renderable for FileMetadata {
             })
             .collect();
 
-        // Calculate centered area for the table
-        let key_width = 18;
-        let value_width = max_value_size.max(20); // Ensure minimum width
-        let table_width = key_width + value_width + 3; // +3 for spacing and borders
+        let key_width = 18u16;
+        let value_width = max_value_size.max(20);
+        let table_width = key_width + value_width + 3;
         let table_height = rows.len() as u16;
         let center_x = area.x + (area.width.saturating_sub(table_width)) / 2;
         let center_y = area.y + (area.height.saturating_sub(table_height)) / 2;
 
-        let centered_area = Rect {
+        // Clamp to area bounds so the stats box never bleeds into the properties panel.
+        let proposed = Rect {
             x: center_x,
             y: center_y,
             width: table_width + 2,
             height: table_height + 2,
         };
+        let centered_area = proposed.intersection(area);
 
         let table = Table::new(
             rows,
@@ -163,6 +224,69 @@ impl Renderable for FileMetadata {
                 .border_set(border::ROUNDED),
         );
         table.render(centered_area, buf);
+    }
+
+    fn render_properties(&self, area: Rect, buf: &mut Buffer, scroll: usize) {
+        let props = &self.key_value_metadata;
+        if props.is_empty() {
+            return;
+        }
+
+        // Build styled display lines: key header then 2-space-indented value (JSON pretty-printed).
+        let mut lines: Vec<Line> = Vec::new();
+        for (i, (key, value)) in props.iter().enumerate() {
+            if i > 0 {
+                lines.push(Line::from(""));
+            }
+            lines.push(Line::from(Span::from(key.as_str()).bold().fg(Color::Blue)));
+            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(value) {
+                let pretty = serde_json::to_string_pretty(&json_val)
+                    .unwrap_or_else(|_| value.clone());
+                for json_line in pretty.lines() {
+                    lines.push(Line::from(format!("  {json_line}")));
+                }
+            } else {
+                lines.push(Line::from(format!("  {value}")));
+            }
+        }
+
+        let total_lines = lines.len();
+        let visible_height = area.height.saturating_sub(2) as usize;
+        let needs_scrollbar = total_lines > visible_height;
+        let start = scroll.min(total_lines.saturating_sub(visible_height));
+
+        let [para_area, scrollbar_area] = Layout::horizontal([
+            Constraint::Fill(1),
+            Constraint::Length(if needs_scrollbar { 1 } else { 0 }),
+        ])
+        .areas(area);
+
+        if needs_scrollbar {
+            ScrollbarComponent::vertical(total_lines, visible_height, start)
+                .render(scrollbar_area, buf);
+        }
+
+        Paragraph::new(Text::from(lines))
+            .scroll((start as u16, 0))
+            .block(
+                Block::bordered()
+                    .title(
+                        Line::from(
+                            Span::from(format!("Properties ({})", props.len()))
+                                .yellow()
+                                .bold(),
+                        )
+                        .centered(),
+                    )
+                    .border_set(border::ROUNDED),
+            )
+            .render(para_area, buf);
+    }
+}
+
+impl Renderable for FileMetadata {
+    fn render_content(&self, area: Rect, buf: &mut Buffer) {
+        self.render_with_scroll(area, buf, 0);
     }
 }
 

--- a/src/file/metadata.rs
+++ b/src/file/metadata.rs
@@ -8,7 +8,7 @@ use ratatui::{
     style::Stylize,
     symbols::border,
     text::{Line, Span, Text},
-    widgets::{Block, Cell, Paragraph, Row, Table},
+    widgets::{Block, Cell, Paragraph, Row, Table, Wrap},
 };
 use std::collections::{HashMap, HashSet};
 
@@ -264,6 +264,7 @@ impl FileMetadata {
         }
 
         Paragraph::new(Text::from(lines))
+            .wrap(Wrap { trim: false })
             .scroll((start as u16, 0))
             .block(
                 Block::bordered()

--- a/src/tabs/manager.rs
+++ b/src/tabs/manager.rs
@@ -19,7 +19,12 @@ pub struct TabManager {
 }
 
 impl TabManager {
-    pub fn new(num_columns: usize, num_row_groups: usize, sample_data_rows: usize) -> Self {
+    pub fn new(
+        num_columns: usize,
+        num_row_groups: usize,
+        sample_data_rows: usize,
+        num_properties: usize,
+    ) -> Self {
         Self {
             tabs: vec![
                 Box::new(
@@ -29,8 +34,7 @@ impl TabManager {
                 ),
                 Box::new(
                     MetadataTab::new()
-                        .with_max_horizontal_scroll(num_columns)
-                        .with_max_vertical_scroll(num_row_groups),
+                        .with_max_vertical_scroll(num_properties.saturating_sub(1)),
                 ),
                 Box::new(SchemaTab::new().with_max_vertical_scroll(num_columns)),
                 Box::new(

--- a/src/tabs/manager.rs
+++ b/src/tabs/manager.rs
@@ -33,8 +33,7 @@ impl TabManager {
                         .with_max_rows(sample_data_rows),
                 ),
                 Box::new(
-                    MetadataTab::new()
-                        .with_max_vertical_scroll(num_properties.saturating_sub(1)),
+                    MetadataTab::new().with_max_vertical_scroll(num_properties.saturating_sub(1)),
                 ),
                 Box::new(SchemaTab::new().with_max_vertical_scroll(num_columns)),
                 Box::new(

--- a/src/tabs/metadata.rs
+++ b/src/tabs/metadata.rs
@@ -41,8 +41,7 @@ impl Tab for MetadataTab {
             match key_event.code {
                 KeyCode::Up if state.vertical_offset() > 0 => state.up(),
                 KeyCode::Down
-                    if state.vertical_offset()
-                        < self.max_vertical_scroll.unwrap_or(usize::MAX) =>
+                    if state.vertical_offset() < self.max_vertical_scroll.unwrap_or(usize::MAX) =>
                 {
                     state.down()
                 }

--- a/src/tabs/metadata.rs
+++ b/src/tabs/metadata.rs
@@ -1,8 +1,9 @@
-use crossterm::event::KeyEvent;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::style::Stylize;
+use ratatui::text::Span;
 use std::io;
 
 use crate::{app::AppState, tabs::Tab};
-use ratatui::text::Span;
 
 pub struct MetadataTab {
     pub max_horizontal_scroll: Option<usize>,
@@ -35,13 +36,34 @@ impl MetadataTab {
 }
 
 impl Tab for MetadataTab {
-    #[allow(unused_variables)]
     fn on_event(&self, key_event: KeyEvent, state: &mut AppState) -> Result<(), io::Error> {
+        if self.max_vertical_scroll.is_some() {
+            match key_event.code {
+                KeyCode::Up if state.vertical_offset() > 0 => state.up(),
+                KeyCode::Down
+                    if state.vertical_offset()
+                        < self.max_vertical_scroll.unwrap_or(usize::MAX) =>
+                {
+                    state.down()
+                }
+                _ => {}
+            }
+        }
         Ok(())
     }
 
     fn instructions(&self) -> Vec<Span<'static>> {
-        vec![]
+        if self.max_vertical_scroll.map(|n| n > 0).unwrap_or(false) {
+            vec![
+                "↑".green(),
+                "/".white(),
+                "↓".blue(),
+                " : ".into(),
+                "Scroll properties".into(),
+            ]
+        } else {
+            vec![]
+        }
     }
 
     fn to_string(&self) -> String {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -158,8 +158,10 @@ impl<'a> AppWidget<'a> {
     }
 
     fn render_metadata_view(&self, area: Rect, buf: &mut Buffer) {
-        // render the metadata
-        self.0.parquet_ctx.metadata.render_content(area, buf);
+        self.0
+            .parquet_ctx
+            .metadata
+            .render_with_scroll(area, buf, self.0.state().vertical_offset());
     }
 
     fn render_schema_view(&self, area: Rect, buf: &mut Buffer) {


### PR DESCRIPTION
## Description

* Adding key-value properties information in the 'Metadata' section of the Parquet file
* Add a new properties size in bytes in the 'Metadata' section


<img width="1053" height="607" alt="Screenshot 2026-07-02 at 21 35 39" src="https://github.com/user-attachments/assets/3ebbd21e-81f3-4db9-911a-4d522d9d735b" />
