### PR TITLE
[feature] handle invalid/corrupted file openings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ dependencies = [
  "polars",
  "ratatui",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = "0.4"                                          # for timestamp handling
 itertools = "0.14.0"
 polars = { version = "0.51.0", features = ["lazy", "parquet", "dtype-full", "timezones"] }
 serde_json = "1"
+thiserror = "2"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/file/error.rs
+++ b/src/file/error.rs
@@ -1,0 +1,90 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FileIOError {
+    #[error("File not found: '{path}'")]
+    FileNotFound { path: PathBuf },
+
+    #[error("Permission denied: '{path}'")]
+    PermissionDenied { path: PathBuf },
+
+    #[error("Not a valid Parquet file: '{path}'\nDetails: {details}")]
+    InvalidParquet { path: PathBuf, details: String },
+
+    #[error("Failed to read file metadata: {details}")]
+    MetadataError { details: String },
+
+    #[error("Failed to read sample data: {details}")]
+    SampleDataError { details: String },
+
+    #[error("File I/O error: {source}")]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_not_found_message() {
+        let err = FileIOError::FileNotFound {
+            path: PathBuf::from("/tmp/nonexistent.parquet"),
+        };
+        assert_eq!(
+            err.to_string(),
+            "File not found: '/tmp/nonexistent.parquet'"
+        );
+    }
+
+    #[test]
+    fn test_permission_denied_message() {
+        let err = FileIOError::PermissionDenied {
+            path: PathBuf::from("/etc/shadow"),
+        };
+        assert_eq!(err.to_string(), "Permission denied: '/etc/shadow'");
+    }
+
+    #[test]
+    fn test_invalid_parquet_message() {
+        let err = FileIOError::InvalidParquet {
+            path: PathBuf::from("bad.parquet"),
+            details: "not a valid parquet magic number".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Not a valid Parquet file: 'bad.parquet'"));
+        assert!(msg.contains("not a valid parquet magic number"));
+    }
+
+    #[test]
+    fn test_metadata_error_message() {
+        let err = FileIOError::MetadataError {
+            details: "corrupt row group".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Failed to read file metadata: corrupt row group"
+        );
+    }
+
+    #[test]
+    fn test_sample_data_error_message() {
+        let err = FileIOError::SampleDataError {
+            details: "unsupported column type".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Failed to read sample data: unsupported column type"
+        );
+    }
+
+    #[test]
+    fn test_io_error_from_conversion() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "disk failure");
+        let err: FileIOError = io_err.into();
+        assert!(err.to_string().contains("disk failure"));
+    }
+}

--- a/src/file/error.rs
+++ b/src/file/error.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_io_error_from_conversion() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "disk failure");
+        let io_err = std::io::Error::other("disk failure");
         let err: FileIOError = io_err.into();
         assert!(err.to_string().contains("disk failure"));
     }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod metadata;
 pub mod parquet_ctx;
 pub mod row_groups;

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -35,16 +35,14 @@ impl ParquetCtx {
 
         let md = reader.metadata();
 
-        let row_groups = RowGroups::from_file_reader(&reader).map_err(|e| {
-            FileIOError::MetadataError {
+        let row_groups =
+            RowGroups::from_file_reader(&reader).map_err(|e| FileIOError::MetadataError {
                 details: format!("Failed to read row groups: {e}"),
-            }
-        })?;
-
-        let metadata =
-            FileMetadata::from_metadata(md).map_err(|e| FileIOError::MetadataError {
-                details: format!("Failed to read file metadata: {e}"),
             })?;
+
+        let metadata = FileMetadata::from_metadata(md).map_err(|e| FileIOError::MetadataError {
+            details: format!("Failed to read file metadata: {e}"),
+        })?;
 
         let schema = FileSchema::from_metadata(md).map_err(|e| FileIOError::MetadataError {
             details: format!("Failed to parse schema: {e}"),
@@ -156,9 +154,6 @@ mod tests {
             crate::file::parquet_test_data()
         );
         let result = ParquetCtx::from_file(&path);
-        assert!(
-            result.is_err(),
-            "Expected error for corrupt parquet file"
-        );
+        assert!(result.is_err(), "Expected error for corrupt parquet file");
     }
 }

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -1,6 +1,8 @@
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
+use std::path::PathBuf;
 
+use crate::file::error::FileIOError;
 use crate::file::metadata::FileMetadata;
 use crate::file::row_groups::RowGroups;
 use crate::file::sample_data::ParquetSampleData;
@@ -14,18 +16,45 @@ pub struct ParquetCtx {
 }
 
 impl ParquetCtx {
-    pub fn from_file(file_path: &str) -> Result<ParquetCtx, Box<dyn std::error::Error>> {
-        let file = File::open(file_path)?;
-        let reader: SerializedFileReader<File> = SerializedFileReader::new(file)?;
+    pub fn from_file(file_path: &str) -> Result<ParquetCtx, FileIOError> {
+        let path = PathBuf::from(file_path);
+
+        let file = File::open(&path).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => FileIOError::FileNotFound { path: path.clone() },
+            std::io::ErrorKind::PermissionDenied => {
+                FileIOError::PermissionDenied { path: path.clone() }
+            }
+            _ => FileIOError::Io { source: e },
+        })?;
+
+        let reader: SerializedFileReader<File> =
+            SerializedFileReader::new(file).map_err(|e| FileIOError::InvalidParquet {
+                path: path.clone(),
+                details: e.to_string(),
+            })?;
+
         let md = reader.metadata();
-        let row_groups = RowGroups::from_file_reader(&reader)?;
 
-        // TODO: async calls?
-        let metadata = FileMetadata::from_metadata(md)?;
-        let schema = FileSchema::from_metadata(md)?;
+        let row_groups = RowGroups::from_file_reader(&reader).map_err(|e| {
+            FileIOError::MetadataError {
+                details: format!("Failed to read row groups: {e}"),
+            }
+        })?;
 
-        // Read sample data
-        let sample_data = ParquetSampleData::read_sample_data(file_path)?;
+        let metadata =
+            FileMetadata::from_metadata(md).map_err(|e| FileIOError::MetadataError {
+                details: format!("Failed to read file metadata: {e}"),
+            })?;
+
+        let schema = FileSchema::from_metadata(md).map_err(|e| FileIOError::MetadataError {
+            details: format!("Failed to parse schema: {e}"),
+        })?;
+
+        let sample_data = ParquetSampleData::read_sample_data(file_path).map_err(|e| {
+            FileIOError::SampleDataError {
+                details: e.to_string(),
+            }
+        })?;
 
         Ok(ParquetCtx {
             file_path: file_path.to_string(),
@@ -38,5 +67,98 @@ impl ParquetCtx {
 
     pub fn column_size(&self) -> usize {
         self.schema.column_size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_data_path(filename: &str) -> String {
+        format!("{}/{}", crate::file::parquet_test_data(), filename)
+    }
+
+    #[test]
+    fn test_file_not_found() {
+        let path = test_data_path("this_file_does_not_exist.parquet");
+        let Err(err) = ParquetCtx::from_file(&path) else {
+            panic!("Expected error for nonexistent file");
+        };
+        assert!(
+            matches!(err, FileIOError::FileNotFound { .. }),
+            "Expected FileNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_non_parquet_file() {
+        let path = test_data_path("README.md");
+        let Err(err) = ParquetCtx::from_file(&path) else {
+            panic!("Expected error for non-parquet file");
+        };
+        assert!(
+            matches!(err, FileIOError::InvalidParquet { .. }),
+            "Expected InvalidParquet, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_valid_parquet_file_alltypes_plain() {
+        let path = test_data_path("alltypes_plain.parquet");
+        let result = ParquetCtx::from_file(&path);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_valid_parquet_file_alltypes_dictionary() {
+        let path = test_data_path("alltypes_dictionary.parquet");
+        let result = ParquetCtx::from_file(&path);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_valid_parquet_file_nulls() {
+        let path = test_data_path("nulls.snappy.parquet");
+        let result = ParquetCtx::from_file(&path);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_file_not_found_error_contains_path() {
+        let path = test_data_path("nonexistent.parquet");
+        let Err(err) = ParquetCtx::from_file(&path) else {
+            panic!("Expected error for nonexistent file");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nonexistent.parquet"),
+            "Error message should contain the file path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_invalid_parquet_error_contains_path() {
+        let path = test_data_path("README.md");
+        let Err(err) = ParquetCtx::from_file(&path) else {
+            panic!("Expected error for non-parquet file");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("README.md"),
+            "Error message should contain the file path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_corrupt_parquet_from_bad_data() {
+        let path = format!(
+            "{}/../../parquet-testing/bad_data/PARQUET-1481.parquet",
+            crate::file::parquet_test_data()
+        );
+        let result = ParquetCtx::from_file(&path);
+        assert!(
+            result.is_err(),
+            "Expected error for corrupt parquet file"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use parqeye::app::App;
+use parqeye::file::error::FileIOError;
 use parqeye::file::parquet_ctx::ParquetCtx;
-use std::io;
 
 use clap::Parser;
 
@@ -15,19 +15,21 @@ pub struct Opts {
     pub path: String,
 }
 
-fn main() -> io::Result<()> {
+fn main() {
     let opts = Opts::parse();
-    tui(&opts.path)?;
-    Ok(())
+    if let Err(e) = run(&opts.path) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
 }
 
-fn tui(path: &str) -> io::Result<()> {
+fn run(path: &str) -> Result<(), FileIOError> {
+    let file_info = ParquetCtx::from_file(path)?;
+
     let mut terminal = ratatui::init();
-
-    let file_info = ParquetCtx::from_file(path).map_err(|e| io::Error::other(e.to_string()))?;
-
     let mut app = App::new(&file_info);
-    app.run(&mut terminal)?;
+    let result = app.run(&mut terminal);
     ratatui::restore();
-    Ok(())
+
+    result.map_err(|e| FileIOError::Io { source: e })
 }


### PR DESCRIPTION
# Description

Current implementation doesn't efficiently handle invalid/corrupted parquet files - the io panics and can mess up the terminal spacing. Use `thiserror` to handle io cases.

# Note

- Downstream packages (e.g. `polars-core`, `polars-mem-engine`) continues to panic when reading bad parquet files - need to look into in a following change.