### PR TITLE
feat: lazily load the the page info to speed up initial load

### DIFF
--- a/src/components/row_group/schema_md.rs
+++ b/src/components/row_group/schema_md.rs
@@ -1,5 +1,8 @@
 use crate::file::utils::human_readable_bytes;
-use crate::file::{row_groups::RowGroupColumnMetadata, utils::commas};
+use crate::file::{
+    row_groups::{RowGroupColumnMetadata, RowGroupPageInfo},
+    utils::commas,
+};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Position, Rect},
@@ -12,11 +15,15 @@ use ratatui::{
 /// Component to display column-level metadata for a selected row group
 pub struct RowGroupColumnMetadataComponent<'a> {
     column_metadata: &'a RowGroupColumnMetadata,
+    pages: &'a RowGroupPageInfo,
 }
 
 impl<'a> RowGroupColumnMetadataComponent<'a> {
-    pub fn new(column_metadata: &'a RowGroupColumnMetadata) -> Self {
-        Self { column_metadata }
+    pub fn new(column_metadata: &'a RowGroupColumnMetadata, pages: &'a RowGroupPageInfo) -> Self {
+        Self {
+            column_metadata,
+            pages,
+        }
     }
 }
 
@@ -241,7 +248,6 @@ impl<'a> RowGroupColumnMetadataComponent<'a> {
 
         // Create rows from page info
         let rows: Vec<Row> = self
-            .column_metadata
             .pages
             .page_infos
             .iter()

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -1,8 +1,11 @@
 use parquet::file::reader::{FileReader, SerializedFileReader};
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fs::File;
+use std::rc::Rc;
 
 use crate::file::metadata::FileMetadata;
-use crate::file::row_groups::RowGroups;
+use crate::file::row_groups::{RowGroupPageInfo, RowGroups, make_page_info};
 use crate::file::sample_data::ParquetSampleData;
 use crate::file::schema::FileSchema;
 pub struct ParquetCtx {
@@ -11,6 +14,10 @@ pub struct ParquetCtx {
     pub row_groups: RowGroups,
     pub schema: FileSchema,
     pub sample_data: ParquetSampleData,
+    /// Retained so page info can be read lazily (reuses the already-parsed footer).
+    reader: SerializedFileReader<File>,
+    /// Caches page info per (row group, column) so it is read/decompressed at most once.
+    page_cache: RefCell<HashMap<(usize, usize), Rc<RowGroupPageInfo>>>,
 }
 
 impl ParquetCtx {
@@ -33,10 +40,41 @@ impl ParquetCtx {
             row_groups,
             schema,
             sample_data,
+            reader,
+            page_cache: RefCell::new(HashMap::new()),
         })
     }
 
     pub fn column_size(&self) -> usize {
         self.schema.column_size()
+    }
+
+    /// Lazily read (and cache) the page info for a single column chunk.
+    ///
+    /// Page enumeration decompresses each page's data buffer, so this is done on
+    /// demand only for the row group / column currently being viewed. Results are
+    /// cached, so re-navigating to the same column is free.
+    pub fn page_info(&self, rg_idx: usize, col_idx: usize) -> Rc<RowGroupPageInfo> {
+        if let Some(pages) = self.page_cache.borrow().get(&(rg_idx, col_idx)) {
+            return Rc::clone(pages);
+        }
+
+        let pages = Rc::new(self.read_page_info(rg_idx, col_idx).unwrap_or_default());
+        self.page_cache
+            .borrow_mut()
+            .insert((rg_idx, col_idx), Rc::clone(&pages));
+        pages
+    }
+
+    fn read_page_info(
+        &self,
+        rg_idx: usize,
+        col_idx: usize,
+    ) -> Result<RowGroupPageInfo, Box<dyn std::error::Error>> {
+        let mut page_reader = self
+            .reader
+            .get_row_group(rg_idx)?
+            .get_column_page_reader(col_idx)?;
+        Ok(make_page_info(&mut page_reader))
     }
 }

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -2,8 +2,8 @@ use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
-use std::rc::Rc;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use crate::file::error::FileIOError;
 use crate::file::metadata::FileMetadata;

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -194,4 +194,67 @@ mod tests {
         let result = ParquetCtx::from_file(&path);
         assert!(result.is_err(), "Expected error for corrupt parquet file");
     }
+
+    #[test]
+    fn test_page_info_reads_pages_for_column() {
+        let path = test_data_path("alltypes_plain.parquet");
+        let ctx = ParquetCtx::from_file(&path).unwrap();
+
+        let pages = ctx.page_info(0, 0);
+
+        assert_eq!(pages.page_infos.len(), 2);
+        assert_eq!(pages.page_infos[0].page_type, "Dictionary Page");
+        assert_eq!(pages.page_infos[1].page_type, "Data Page");
+    }
+
+    #[test]
+    fn test_page_info_differs_per_column() {
+        let path = test_data_path("alltypes_plain.parquet");
+        let ctx = ParquetCtx::from_file(&path).unwrap();
+
+        // Column 1 (bool) has no dictionary page, unlike column 0.
+        let pages = ctx.page_info(0, 1);
+
+        assert_eq!(pages.page_infos.len(), 1);
+        assert_eq!(pages.page_infos[0].page_type, "Data Page");
+    }
+
+    #[test]
+    fn test_page_info_handles_many_pages() {
+        let path = test_data_path("alltypes_tiny_pages.parquet");
+        let ctx = ParquetCtx::from_file(&path).unwrap();
+
+        let pages = ctx.page_info(0, 0);
+
+        assert_eq!(pages.page_infos.len(), 325);
+    }
+
+    #[test]
+    fn test_page_info_caches_repeated_lookups() {
+        let path = test_data_path("alltypes_plain.parquet");
+        let ctx = ParquetCtx::from_file(&path).unwrap();
+
+        let first = ctx.page_info(0, 0);
+        let second = ctx.page_info(0, 0);
+
+        assert!(
+            Rc::ptr_eq(&first, &second),
+            "expected cached page info to be reused rather than re-read"
+        );
+        assert_eq!(ctx.page_cache.borrow().len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds")]
+    fn test_page_info_out_of_range_row_group_panics() {
+        // `unwrap_or_default()` in `page_info` only catches `Err`s from
+        // `read_page_info`, but the underlying `parquet` crate indexes into its
+        // row group vector directly and panics on an out-of-range index rather
+        // than returning `Err`. Documenting this so a caller doesn't assume
+        // `page_info` is panic-safe for arbitrary indices.
+        let path = test_data_path("alltypes_plain.parquet");
+        let ctx = ParquetCtx::from_file(&path).unwrap();
+
+        ctx.page_info(99, 99);
+    }
 }

--- a/src/file/row_groups.rs
+++ b/src/file/row_groups.rs
@@ -8,6 +8,7 @@ use parquet::file::statistics::Statistics;
 use itertools::Itertools;
 use std::iter::Iterator;
 
+#[derive(Default)]
 pub struct RowGroupPageInfo {
     pub page_infos: Vec<PageInfo>,
 }
@@ -41,7 +42,6 @@ pub struct RowGroupColumnMetadata {
     pub total_compressed_size: i64,
     pub total_uncompressed_size: i64,
     pub compression_type: String,
-    pub pages: RowGroupPageInfo,
 }
 
 pub struct RowGroupAvgMedianStats {
@@ -173,11 +173,6 @@ impl RowGroupColumnMetadata {
         let rg_md = reader.metadata().row_group(rg_idx);
         let column_chunk: &ColumnChunkMetaData = rg_md.column(col_idx);
 
-        let mut page_reader = reader
-            .get_row_group(rg_idx)?
-            .get_column_page_reader(col_idx)?;
-        let pages = Self::make_page_info(&mut page_reader)?;
-
         let statistics = RowGroupColumnStats::new(column_chunk.statistics());
 
         Ok(RowGroupColumnMetadata {
@@ -194,24 +189,22 @@ impl RowGroupColumnMetadata {
             total_compressed_size: column_chunk.compressed_size(),
             total_uncompressed_size: column_chunk.uncompressed_size(),
             compression_type: column_chunk.compression().to_string(),
-            pages,
         })
     }
+}
 
-    fn make_page_info(
-        page_reader: &mut Box<dyn PageReader>,
-    ) -> Result<RowGroupPageInfo, Box<dyn std::error::Error>> {
-        let mut page_info = Vec::new();
-        while let Ok(page) = page_reader.get_next_page() {
-            if let Some(page) = page {
-                page_info.push(PageInfo::from(&page));
-            } else {
-                break;
-            }
-        }
-        Ok(RowGroupPageInfo {
-            page_infos: page_info,
-        })
+/// Enumerate the pages of a single column chunk.
+///
+/// This reads (and decompresses) each page's data buffer, so it is intentionally
+/// called lazily — only for the row group / column the user is currently viewing —
+/// rather than eagerly for the whole file. See `ParquetCtx::page_info`.
+pub(crate) fn make_page_info(page_reader: &mut Box<dyn PageReader>) -> RowGroupPageInfo {
+    let mut page_info = Vec::new();
+    while let Ok(Some(page)) = page_reader.get_next_page() {
+        page_info.push(PageInfo::from(&page));
+    }
+    RowGroupPageInfo {
+        page_infos: page_info,
     }
 }
 

--- a/src/file/row_groups.rs
+++ b/src/file/row_groups.rs
@@ -272,3 +272,69 @@ impl RowGroupColumnStats {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_data_path(filename: &str) -> String {
+        format!("{}/{}", crate::file::parquet_test_data(), filename)
+    }
+
+    fn open_reader(filename: &str) -> SerializedFileReader<std::fs::File> {
+        let path = test_data_path(filename);
+        let file = std::fs::File::open(&path).unwrap();
+        SerializedFileReader::new(file).unwrap()
+    }
+
+    #[test]
+    fn test_make_page_info_reads_dictionary_and_data_pages() {
+        let reader = open_reader("alltypes_plain.parquet");
+        let mut page_reader = reader
+            .get_row_group(0)
+            .unwrap()
+            .get_column_page_reader(0)
+            .unwrap();
+
+        let pages = make_page_info(&mut page_reader);
+
+        assert_eq!(pages.page_infos.len(), 2);
+        assert_eq!(pages.page_infos[0].page_type, "Dictionary Page");
+        assert_eq!(pages.page_infos[1].page_type, "Data Page");
+        // The dictionary/plain files have a single row group of 8 rows.
+        assert_eq!(pages.page_infos[1].rows, 8);
+    }
+
+    #[test]
+    fn test_make_page_info_no_dictionary_page_for_bool_column() {
+        let reader = open_reader("alltypes_plain.parquet");
+        // Column 1 is the boolean column, which parquet never dictionary-encodes.
+        let mut page_reader = reader
+            .get_row_group(0)
+            .unwrap()
+            .get_column_page_reader(1)
+            .unwrap();
+
+        let pages = make_page_info(&mut page_reader);
+
+        assert_eq!(pages.page_infos.len(), 1);
+        assert_eq!(pages.page_infos[0].page_type, "Data Page");
+    }
+
+    #[test]
+    fn test_row_group_page_info_default_is_empty() {
+        let pages = RowGroupPageInfo::default();
+        assert!(pages.page_infos.is_empty());
+    }
+
+    #[test]
+    fn test_row_group_column_metadata_from_file_reader_succeeds_without_reading_pages() {
+        // Regression test for the lazy page loading change: building column metadata
+        // must not require (or fail because of) page enumeration.
+        let reader = open_reader("alltypes_plain.parquet");
+        let metadata = RowGroupColumnMetadata::from_file_reader(&reader, 0, 0).unwrap();
+
+        assert_eq!(metadata.column_path, "\"id\"");
+        assert!(metadata.has_stats.has_dictionary_page);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -231,9 +231,13 @@ impl<'a> AppWidget<'a> {
         .render(rg_progress, buf);
 
         if self.0.state().vertical_offset() > 0 {
+            let rg_idx = self.0.state().horizontal_offset();
+            let col_idx = self.0.state().vertical_offset() - 1;
+            // Read this column's pages lazily (and cached) — only the selected column.
+            let pages = self.0.parquet_ctx.page_info(rg_idx, col_idx);
             RowGroupColumnMetadataComponent::new(
-                &self.0.parquet_ctx.row_groups.row_groups[self.0.state().horizontal_offset()]
-                    .column_metadata[self.0.state().vertical_offset() - 1],
+                &self.0.parquet_ctx.row_groups.row_groups[rg_idx].column_metadata[col_idx],
+                &pages,
             )
             .render(central_area, buf);
         } else {


### PR DESCRIPTION
# Description

* When the parquet file is loaded, all the page infos for all the row groups are eagerly loaded. This slows down the initial load of the file and reduces snappiness. We use a new `page_cache` which is a mutable hashmap. The program loads from the `page_cache` on successive row group load.