### PR TITLE
feat: support large parquet files

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -155,6 +155,18 @@ impl AppState {
         self.adjust_scroll_to_selection(visible_rows, max_rows);
     }
 
+    /// Jump the selection (and viewport) to the first row.
+    pub fn jump_to_top(&mut self) {
+        self.vertical_offset = 0;
+        self.data_vertical_scroll = 0;
+    }
+
+    /// Jump the selection (and viewport) to the last row.
+    pub fn jump_to_bottom(&mut self, visible_rows: usize, max_rows: usize) {
+        self.vertical_offset = max_rows.saturating_sub(1);
+        self.adjust_scroll_to_selection(visible_rows, max_rows);
+    }
+
     pub fn adjust_scroll_to_selection(&mut self, visible_rows: usize, max_rows: usize) {
         // Ensure selected row is visible in viewport
         if self.vertical_offset < self.data_vertical_scroll {
@@ -290,6 +302,19 @@ mod tests {
         state.left();
         state.left();
         assert_eq!(state.horizontal_offset(), 0);
+    }
+
+    #[test]
+    fn test_jump_to_bottom_then_top() {
+        let mut state = AppState::new();
+
+        state.jump_to_bottom(20, 7300);
+        assert_eq!(state.vertical_offset(), 7299);
+        assert_eq!(state.data_vertical_scroll(), 7300 - 20);
+
+        state.jump_to_top();
+        assert_eq!(state.vertical_offset(), 0);
+        assert_eq!(state.data_vertical_scroll(), 0);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -199,6 +199,14 @@ impl<'a> App<'a> {
             let visible_data_rows = (terminal_size.height.saturating_sub(7) as usize).max(1);
             self.state.set_visible_data_rows(visible_data_rows);
 
+            // Lazily (re)load the row window backing the Visualize table so only a
+            // bounded slice of a large file is ever held in memory.
+            if self.tabs.active_tab().to_string() == "Visualize" {
+                self.parquet_ctx
+                    .sample_data
+                    .ensure_loaded(self.state.data_vertical_scroll(), visible_data_rows);
+            }
+
             // Bound horizontal column scrolling on the Visualize tab to what
             // actually fits, so it can't overshoot the last visible column (which
             // left phantom offset, causing "empty" presses when scrolling back).

--- a/src/components/data_table.rs
+++ b/src/components/data_table.rs
@@ -11,6 +11,7 @@ use ratatui::{
 use std::cmp::min;
 
 use crate::file::Renderable;
+use crate::file::utils::commas;
 
 const NUM_SPACES_BETWEEN_COLUMNS: u16 = 2;
 const NUM_SPACES_AFTER_LINE_NUMBER: u16 = 2;
@@ -62,7 +63,7 @@ impl<'a> DataTable<'a> {
     pub fn new(data: &'a ParquetSampleData) -> Self {
         Self {
             data,
-            title: "Data Preview (up to 100 rows)".to_string(),
+            title: format!("Data Preview ({} rows)", commas(data.total_rows as u64)),
             title_color: Color::Cyan,
             border_style: border::ROUNDED,
             horizontal_scroll: 0,
@@ -130,14 +131,18 @@ impl<'a> DataTable<'a> {
     /// Rendered width of every column (from the rows in view). Basis for both the
     /// scroll bound and how many columns are drawn, so they stay in agreement.
     fn all_column_widths(&self) -> Vec<u16> {
-        let start = self.vertical_scroll.min(self.data.rows.len());
-        self.calculate_column_widths(&self.data.flattened_columns, &self.data.rows[start..])
+        let win = self.data.loaded();
+        let start = self
+            .vertical_scroll
+            .saturating_sub(win.start)
+            .min(win.rows.len());
+        self.calculate_column_widths(&self.data.flattened_columns, &win.rows[start..])
     }
 
     /// Maximum horizontal scroll offset for a render area `area_width` wide,
     /// sized from actual column widths so the last column is always reachable.
     pub fn max_horizontal_scroll(&self, area_width: u16) -> usize {
-        let max_row_num = self.data.rows.len().saturating_sub(self.vertical_scroll);
+        let max_row_num = self.data.total_rows.saturating_sub(self.vertical_scroll);
         let row_num_section_width =
             (format!("{max_row_num}").len().max(4) as u16) + 2 * NUM_SPACES_AFTER_LINE_NUMBER + 1;
         let available_width = area_width.saturating_sub(row_num_section_width);
@@ -318,8 +323,10 @@ impl<'a> Widget for DataTable<'a> {
             return;
         }
 
+        let win = self.data.loaded();
+
         // Calculate row number section width
-        let max_row_num = self.data.rows.len().saturating_sub(self.vertical_scroll);
+        let max_row_num = self.data.total_rows.saturating_sub(self.vertical_scroll);
         let max_row_num_length = format!("{}", max_row_num).len().max(4) as u16;
         let row_num_section_width = max_row_num_length + 2 * NUM_SPACES_AFTER_LINE_NUMBER + 1;
         let x_row_separator = max_row_num_length + NUM_SPACES_AFTER_LINE_NUMBER + 1;
@@ -346,12 +353,13 @@ impl<'a> Widget for DataTable<'a> {
             .cloned()
             .collect();
 
-        // Get visible data for each row (apply vertical scroll)
-        let visible_rows: Vec<Vec<String>> = self
-            .data
+        // Get visible data for each row (apply vertical scroll). Rows live in a
+        // bounded window; index into it relative to the window start.
+        let row_skip = self.vertical_scroll.saturating_sub(win.start);
+        let visible_rows: Vec<Vec<String>> = win
             .rows
             .iter()
-            .skip(self.vertical_scroll)
+            .skip(row_skip)
             .map(|row| {
                 row.iter()
                     .skip(horizontal_scroll)

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -55,11 +55,12 @@ impl ParquetCtx {
             details: format!("Failed to parse schema: {e}"),
         })?;
 
-        let sample_data = ParquetSampleData::read_sample_data(file_path).map_err(|e| {
-            FileIOError::SampleDataError {
-                details: e.to_string(),
-            }
-        })?;
+        let sample_data =
+            ParquetSampleData::open(file_path, metadata.num_rows).map_err(|e| {
+                FileIOError::SampleDataError {
+                    details: e.to_string(),
+                }
+            })?;
 
         Ok(ParquetCtx {
             file_path: file_path.to_string(),

--- a/src/file/parquet_ctx.rs
+++ b/src/file/parquet_ctx.rs
@@ -55,12 +55,11 @@ impl ParquetCtx {
             details: format!("Failed to parse schema: {e}"),
         })?;
 
-        let sample_data =
-            ParquetSampleData::open(file_path, metadata.num_rows).map_err(|e| {
-                FileIOError::SampleDataError {
-                    details: e.to_string(),
-                }
-            })?;
+        let sample_data = ParquetSampleData::open(file_path, metadata.num_rows).map_err(|e| {
+            FileIOError::SampleDataError {
+                details: e.to_string(),
+            }
+        })?;
 
         Ok(ParquetCtx {
             file_path: file_path.to_string(),

--- a/src/file/sample_data.rs
+++ b/src/file/sample_data.rs
@@ -1,67 +1,148 @@
+use std::cell::{Ref, RefCell};
+
 use polars::prelude::*;
 
-#[derive(Debug, Clone)]
-pub struct ParquetSampleData {
-    pub flattened_columns: Vec<String>,
+/// String cells for a slice of rows, paired with the (flattened) column names.
+type LoadedRows = (Vec<Vec<String>>, Vec<String>);
+
+/// Hard cap on the number of rows materialized in memory at any time.
+const WINDOW_ROWS: usize = 2000;
+/// Rows kept before the viewport when a reload is triggered, so scrolling back
+/// up a little does not immediately force another reload.
+const ROW_PREFETCH: usize = 500;
+
+/// The currently materialized slice of rows: `rows[i]` is the file row at
+/// absolute index `start + i`.
+#[derive(Debug, Default)]
+pub struct RowWindow {
+    pub start: usize,
     pub rows: Vec<Vec<String>>,
-    pub total_columns: usize,
-    pub total_rows: usize,
 }
 
-// TODO: in future create a independent crate that does the parsing,
-// the polars crate is large and doesn't support complex nested types.
-impl ParquetSampleData {
-    pub fn read_sample_data(
-        file_path: &str,
-    ) -> Result<ParquetSampleData, Box<dyn std::error::Error>> {
-        const MAX_ROWS: usize = 200;
+impl RowWindow {
+    /// Whether `[view_start, view_start + view_len)` is fully covered.
+    fn covers(&self, view_start: usize, view_len: usize) -> bool {
+        view_start >= self.start && view_start + view_len <= self.start + self.rows.len()
+    }
+}
 
-        // Read parquet file using polars LazyFrame
+/// A lazily-loaded, memory-bounded view over a parquet file's rows.
+///
+/// Only a sliding window of at most [`WINDOW_ROWS`] rows is held in memory; the
+/// window is reloaded from the file (via a pushed-down slice) whenever the
+/// viewport scrolls outside it. Column names and the total row count are known
+/// up front from the file's schema/metadata.
+#[derive(Debug)]
+pub struct ParquetSampleData {
+    file_path: String,
+    pub flattened_columns: Vec<String>,
+    pub total_columns: usize,
+    pub total_rows: usize,
+    window: RefCell<RowWindow>,
+}
+
+impl ParquetSampleData {
+    /// Open `file_path` and load the first window of rows. `total_rows` is the
+    /// row count from the parquet metadata (the caller already has it).
+    pub fn open(
+        file_path: &str,
+        total_rows: usize,
+    ) -> Result<ParquetSampleData, Box<dyn std::error::Error>> {
+        let first_len = WINDOW_ROWS.min(total_rows);
+        let (rows, columns) = if first_len > 0 {
+            Self::load(file_path, 0, first_len)?
+        } else {
+            // Empty file: take column names from the lazy schema, no data read.
+            let mut lf = LazyFrame::scan_parquet(PlPath::new(file_path), Default::default())?;
+            let schema = lf.collect_schema()?;
+            let names = schema.iter_names().map(|s| s.to_string()).collect();
+            (Vec::new(), names)
+        };
+
+        Ok(ParquetSampleData {
+            file_path: file_path.to_string(),
+            total_columns: columns.len(),
+            flattened_columns: columns,
+            total_rows,
+            window: RefCell::new(RowWindow { start: 0, rows }),
+        })
+    }
+
+    /// Read `len` rows starting at absolute row `offset`, returning the string
+    /// cells and the (flattened) column names.
+    ///
+    /// polars pushes the slice into the parquet scan, so only the row groups
+    /// overlapping `[offset, offset + len)` are read and decompressed.
+    fn load(
+        file_path: &str,
+        offset: usize,
+        len: usize,
+    ) -> Result<LoadedRows, Box<dyn std::error::Error>> {
         let df = LazyFrame::scan_parquet(PlPath::new(file_path), Default::default())?
-            .limit(MAX_ROWS as u32)
+            .slice(offset as i64, len as IdxSize)
             .collect()?;
 
-        // Flatten struct columns
+        // Flatten struct columns (currently a no-op; see below).
         let df = Self::flatten_struct_columns(df)?;
 
-        // Get column names
-        let flattened_columns: Vec<String> = df
+        let columns: Vec<String> = df
             .get_column_names()
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let total_columns = flattened_columns.len();
-
-        // Convert dataframe to rows of strings
-        let mut rows = Vec::new();
+        let mut rows = Vec::with_capacity(df.height());
         for row_idx in 0..df.height() {
-            let mut row = Vec::new();
+            let mut row = Vec::with_capacity(columns.len());
             for col in df.get_columns() {
                 let series = col.as_materialized_series();
-                let value = Self::get_value_as_string(series, row_idx);
-                row.push(value);
+                row.push(Self::get_value_as_string(series, row_idx));
             }
             rows.push(row);
         }
 
-        Ok(ParquetSampleData {
-            total_columns,
-            flattened_columns,
-            rows,
-            total_rows: df.height(),
-        })
+        Ok((rows, columns))
+    }
+
+    /// Ensure the window covers `[view_start, view_start + view_len)`, reloading
+    /// from the file if it does not. A reload failure leaves the current window
+    /// in place rather than panicking.
+    pub fn ensure_loaded(&self, view_start: usize, view_len: usize) {
+        let view_len = view_len.min(self.total_rows.saturating_sub(view_start));
+        {
+            if self.window.borrow().covers(view_start, view_len) {
+                return;
+            }
+        }
+
+        let new_start = view_start.saturating_sub(ROW_PREFETCH);
+        let len = WINDOW_ROWS.min(self.total_rows.saturating_sub(new_start));
+        if len == 0 {
+            return;
+        }
+
+        if let Ok((rows, _columns)) = Self::load(&self.file_path, new_start, len) {
+            let mut window = self.window.borrow_mut();
+            window.start = new_start;
+            window.rows = rows;
+        }
+    }
+
+    /// The currently materialized row window.
+    pub fn loaded(&self) -> Ref<'_, RowWindow> {
+        self.window.borrow()
     }
 
     fn flatten_struct_columns(df: DataFrame) -> Result<DataFrame, Box<dyn std::error::Error>> {
-        // For now, we'll just return the dataframe as-is
-        // Struct columns will be displayed with their string representation
-        // TODO: Add proper struct flattening if needed
+        // For now, we'll just return the dataframe as-is.
+        // Struct columns are displayed with their string representation.
+        // TODO: Add proper struct flattening if needed. If flattening changes the
+        // column set, `load`'s projection (a future optimization) will need a
+        // flattened -> physical name map.
         Ok(df)
     }
 
     fn get_value_as_string(col: &Series, row_idx: usize) -> String {
-        // Use get() which returns AnyValue and handle it
         match col.get(row_idx) {
             Ok(any_value) => {
                 if any_value.is_null() {
@@ -72,5 +153,67 @@ impl ParquetSampleData {
             }
             Err(_) => "NULL".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_data_path(filename: &str) -> String {
+        format!("{}/{}", crate::file::parquet_test_data(), filename)
+    }
+
+    // alltypes_tiny_pages.parquet: 7300 rows, 13 columns — larger than WINDOW_ROWS.
+    fn wide_file() -> String {
+        test_data_path("alltypes_tiny_pages.parquet")
+    }
+
+    #[test]
+    fn open_reports_full_metadata_not_just_the_window() {
+        let data = ParquetSampleData::open(&wide_file(), 7300).unwrap();
+
+        assert_eq!(data.total_rows, 7300);
+        assert_eq!(data.total_columns, 13);
+        assert_eq!(data.flattened_columns.len(), data.total_columns);
+        // Only a bounded window is actually materialized.
+        assert_eq!(data.loaded().rows.len(), WINDOW_ROWS);
+        assert_eq!(data.loaded().start, 0);
+    }
+
+    #[test]
+    fn ensure_loaded_slides_the_window_for_a_far_scroll() {
+        let data = ParquetSampleData::open(&wide_file(), 7300).unwrap();
+
+        data.ensure_loaded(6000, 40);
+
+        let win = data.loaded();
+        assert!(win.start > 0, "window should have moved");
+        assert_eq!(win.start, 6000 - ROW_PREFETCH);
+        // The requested viewport is covered.
+        assert!(win.covers(6000, 40));
+        // Still bounded (only 7300 - start rows remain, but never more than the cap).
+        assert!(win.rows.len() <= WINDOW_ROWS);
+    }
+
+    #[test]
+    fn ensure_loaded_is_a_noop_inside_the_window() {
+        let data = ParquetSampleData::open(&wide_file(), 7300).unwrap();
+        let start_before = data.loaded().start;
+
+        data.ensure_loaded(50, 40);
+
+        assert_eq!(data.loaded().start, start_before);
+    }
+
+    #[test]
+    fn windowed_rows_match_a_direct_read_at_the_same_offset() {
+        let data = ParquetSampleData::open(&wide_file(), 7300).unwrap();
+        data.ensure_loaded(6000, 10);
+
+        let (direct, _) = ParquetSampleData::load(&wide_file(), 6000, 10).unwrap();
+        let win = data.loaded();
+        let rel = 6000 - win.start;
+        assert_eq!(&win.rows[rel..rel + 10], &direct[..]);
     }
 }

--- a/src/tabs/visualize.rs
+++ b/src/tabs/visualize.rs
@@ -68,6 +68,11 @@ impl Tab for VisualizeTab {
             KeyCode::Char('d') | KeyCode::Char('D') => {
                 state.page_down(visible_rows, max_rows);
             }
+            // Jump to first / last row (vim-style g/G, or Home/End)
+            KeyCode::Char('g') | KeyCode::Home => state.jump_to_top(),
+            KeyCode::Char('G') | KeyCode::End => {
+                state.jump_to_bottom(visible_rows, max_rows);
+            }
             // Column navigation (Left/Right arrows)
             KeyCode::Left if state.horizontal_offset() > 0 => state.left(),
             // Upper bound is enforced in AppState against the on-screen column
@@ -97,6 +102,12 @@ impl Tab for VisualizeTab {
             "d".blue(),
             " : ".into(),
             "Page".into(),
+            " | ".white(),
+            "g".green(),
+            "/".white(),
+            "G".blue(),
+            " : ".into(),
+            "Top/Bottom".into(),
         ]
     }
 


### PR DESCRIPTION
# Description

The current implementation limits the size of the parquet file to 200. To reduce memory footprint, we can pre-emptively load 2000 rows and revolve the window as we scroll. 

## Future Enhancements

* All columns are loaded - we could create a 2D cache
* Asynchronously load based on user movements