### PR TITLE
fix: update distinct count and file offset to be N/A

### DIFF
--- a/src/components/row_group/schema_md.rs
+++ b/src/components/row_group/schema_md.rs
@@ -93,31 +93,40 @@ impl<'a> RowGroupColumnMetadataComponent<'a> {
             "N/A".to_string()
         };
 
+        let file_offset = match self.column_metadata.file_offset {
+            Some(offset) => Cell::from(commas(offset)).fg(Color::White),
+            None => Cell::from("N/A").fg(Color::DarkGray),
+        };
+
         let kv_pairs = vec![
-            ("File Offset (B)", commas(self.column_metadata.file_offset)),
+            ("File Offset (B)", file_offset),
             (
                 "Compressed Size",
-                human_readable_bytes(self.column_metadata.total_compressed_size as u64),
+                Cell::from(human_readable_bytes(
+                    self.column_metadata.total_compressed_size as u64,
+                ))
+                .fg(Color::White),
             ),
             (
                 "Uncompressed Size",
-                human_readable_bytes(self.column_metadata.total_uncompressed_size as u64),
+                Cell::from(human_readable_bytes(
+                    self.column_metadata.total_uncompressed_size as u64,
+                ))
+                .fg(Color::White),
             ),
-            ("Compression Ratio", compression_ratio),
+            (
+                "Compression Ratio",
+                Cell::from(compression_ratio).fg(Color::White),
+            ),
             (
                 "Compression Type",
-                self.column_metadata.compression_type.clone(),
+                Cell::from(self.column_metadata.compression_type.clone()).fg(Color::White),
             ),
         ];
 
         let rows: Vec<Row> = kv_pairs
             .into_iter()
-            .map(|(k, v)| {
-                Row::new(vec![
-                    Cell::from(k).bold().fg(Color::Cyan),
-                    Cell::from(v).fg(Color::White),
-                ])
-            })
+            .map(|(k, v)| Row::new(vec![Cell::from(k).bold().fg(Color::Cyan), v]))
             .collect();
 
         let table = Table::new(rows, vec![Constraint::Length(18), Constraint::Fill(1)]).block(
@@ -202,26 +211,27 @@ impl<'a> RowGroupColumnMetadataComponent<'a> {
                 .map(|c| c.to_string())
                 .unwrap_or_else(|| "N/A".to_string());
 
-            let distinct_count_str = stats
-                .distinct_count
-                .map(|c| c.to_string())
-                .unwrap_or_else(|| "N/A".to_string());
+            let distinct_count = match stats.distinct_count {
+                Some(count) => Cell::from(count.to_string()).fg(Color::White),
+                None => Cell::from("N/A").fg(Color::DarkGray),
+            };
 
             let stat_pairs = vec![
-                ("Min", stats.min.as_deref().unwrap_or("N/A").to_string()),
-                ("Max", stats.max.as_deref().unwrap_or("N/A").to_string()),
-                ("Null Count", null_count_str),
-                ("Distinct Count", distinct_count_str),
+                (
+                    "Min",
+                    Cell::from(stats.min.as_deref().unwrap_or("N/A").to_string()).fg(Color::White),
+                ),
+                (
+                    "Max",
+                    Cell::from(stats.max.as_deref().unwrap_or("N/A").to_string()).fg(Color::White),
+                ),
+                ("Null Count", Cell::from(null_count_str).fg(Color::White)),
+                ("Distinct Count", distinct_count),
             ];
 
             let rows: Vec<Row> = stat_pairs
                 .into_iter()
-                .map(|(k, v)| {
-                    Row::new(vec![
-                        Cell::from(k).bold().fg(Color::Magenta),
-                        Cell::from(v).fg(Color::White),
-                    ])
-                })
+                .map(|(k, v)| Row::new(vec![Cell::from(k).bold().fg(Color::Magenta), v]))
                 .collect();
 
             let table = Table::new(rows, vec![Constraint::Length(18), Constraint::Fill(1)]).block(

--- a/src/file/row_groups.rs
+++ b/src/file/row_groups.rs
@@ -35,7 +35,8 @@ pub struct RowGroupColumnStats {
 }
 
 pub struct RowGroupColumnMetadata {
-    pub file_offset: u64,
+    /// `None` when the writer did not populate the (deprecated) `file_offset` field.
+    pub file_offset: Option<u64>,
     pub column_path: String,
     pub has_stats: HasStats,
     pub statistics: Option<RowGroupColumnStats>,
@@ -176,7 +177,10 @@ impl RowGroupColumnMetadata {
         let statistics = RowGroupColumnStats::new(column_chunk.statistics());
 
         Ok(RowGroupColumnMetadata {
-            file_offset: column_chunk.file_offset() as u64,
+            // file offset deprecated, show N/A if it is not valid
+            file_offset: u64::try_from(column_chunk.file_offset())
+                .ok()
+                .filter(|&offset| offset > 0),
             column_path: column_chunk.column_descr().path().to_string(),
             has_stats: HasStats {
                 has_stats: column_chunk.statistics().is_some(),


### PR DESCRIPTION
# Description

* `file_offset` has been deprecated (https://github.com/apache/parquet-format/pull/440), but some writers still write values to the fields. Use N/A instead if the file offset is unset (0). 
* Update color for `distinct_count`